### PR TITLE
Fix hero translation typo

### DIFF
--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,6 +1,6 @@
 {
   "hero": {
-    "title": "Rent your Yach and jet Ski in Miami Beach!",
+    "title": "Rent your Yacht and Jet Ski in Miami Beach!",
     "subtitle": "Feel the thrill on the water with LuxeWave Rentals 🌊🏖️"
   },
   "button": {


### PR DESCRIPTION
## Summary
- fix spelling in hero title

## Testing
- `grep -n "Rent your" -n src/locales/en/translation.json`

------
https://chatgpt.com/codex/tasks/task_e_686b2053f53c8325a51ecda7a3393911