### PR TITLE
Fix Register error handling

### DIFF
--- a/src/components/Register.jsx
+++ b/src/components/Register.jsx
@@ -18,7 +18,7 @@ export default function Register() {
     setError('');
 
     if (password !== confirm) {
-      setError(err.message);
+      setError('Las contraseñas no coinciden');
       return;
     }
 
@@ -42,7 +42,7 @@ export default function Register() {
       } else if (err.code === 'auth/weak-password') {
         setError('La contraseña debe tener al menos 6 caracteres');
       } else {
-        setError(err.message);;
+        setError(err.message);
       }
     }
   };
@@ -64,7 +64,7 @@ export default function Register() {
       navigate('/dashboard');
     } catch (err) {
       console.error(err);
-      setErrorsetError(err.message);;
+      setError(err.message);
     }
   };
 


### PR DESCRIPTION
## Summary
- show password mismatch message during registration
- fix Google registration error handler

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b21a0698c8325b527e3f91fa6fc0c