### PR TITLE
Fix CORS header order in stripe checkout

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -62,11 +62,13 @@ exports.createStripeCheckout = functions.https.onRequest((req, res) => {
         cancel_url: 'https://luxewave-rentals.vercel.app/cancel',
       });
 
-      res.status(200).json({ url: session.url });
+      // Set CORS headers **before** sending the response
       res.set('Access-Control-Allow-Origin', '*'); // o el origen de tu frontend
       res.set('Access-Control-Allow-Methods', 'POST');
 
-      console.log("Body recibido en createStripeCheckout:", req.body);
+      res.status(200).json({ url: session.url });
+
+      console.log('Body recibido en createStripeCheckout:', req.body);
     } catch (error) {
 
       console.error('Error en createStripeCheckout:', error);


### PR DESCRIPTION
## Summary
- fix ordering of CORS header logic in cloud function for Stripe

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `cd functions && npm test` *(fails: Missing script)*
- `npm run lint` in functions *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686b16b2cdb483259884fe0a8561aa62